### PR TITLE
Downgrade the application version to .NET 3.1

### DIFF
--- a/.github/workflows/main_sampleweb-89430.yml
+++ b/.github/workflows/main_sampleweb-89430.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '3.1.x'
           include-prerelease: true
 
       - name: Build with dotnet

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build-env
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -10,7 +10,7 @@ COPY ./ ./
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
+FROM mcr.microsoft.com/dotnet/aspnet:3.1
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "TodoApi.dll"]

--- a/TodoApi/TodoApi.csproj
+++ b/TodoApi/TodoApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Downgrade the application version to .NET 3.1.

* **TodoApi/TodoApi.csproj**
  - Change the `<TargetFramework>` value from `net6.0` to `netcoreapp3.1`.

* **.github/workflows/main_sampleweb-89430.yml**
  - Change the `dotnet-version` value from `6.0.x` to `3.1.x` in the `Set up .NET Core` step.

* **Dockerfile**
  - Change the base image from `mcr.microsoft.com/dotnet/sdk:6.0` to `mcr.microsoft.com/dotnet/sdk:3.1`.
  - Change the runtime image from `mcr.microsoft.com/dotnet/aspnet:6.0` to `mcr.microsoft.com/dotnet/aspnet:3.1`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sonusathyadas/todoapi/pull/3?shareId=f5ee987c-1c21-4961-ac0c-b9912f9cc0c5).